### PR TITLE
add function to write directly to a file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1211,12 +1211,24 @@ def testThreadsWithNodes(label, nbthread) {
     }
 }
 
+def testWriteToFile() {
+    node(LABEL_TEST_AGENT) {
+        def expected = logparser.getLogsWithBranchInfo()
+
+        logparser.writeLogsWithBranchInfo(env.NODE_NAME, "${pwd()}/logs_write.txt")
+        assert readFile('logs_write.txt') == expected
+    }
+}
+
+
+
 // ===============
 // = run tests   =
 // ===============
 
 testLogparser()
 testCompletedJobs()
+testWriteToFile()
 // test with less nodes than executor
 testThreadsWithNodes(LABEL_TEST_AGENT, 2)
 // same with more than executors available


### PR DESCRIPTION
based on https://github.com/gdemengin/pipeline-logparser/pull/18 but with 2 separate functions (instead of a new option)
- `void writeLogsWithBranchInfo(hudson.FilePath filePath, java.util.LinkedHashMap options = [:], build = currentBuild)`
writes the logs directly in the filePath object
- `void writeLogsWithBranchInfo(String node, String path, java.util.LinkedHashMap options = [:], build = currentBuild)`
same to create the hudson.FilePath from node and Path